### PR TITLE
Configurable reference database

### DIFF
--- a/src/main/scala/metagenomica/bundles/blast16s.scala
+++ b/src/main/scala/metagenomica/bundles/blast16s.scala
@@ -1,6 +1,8 @@
 package ohnosequences.mg7.bundles
 
 import ohnosequences.statika._
+import ohnosequences.loquat.utils._
+import ohnosequences.awstools.s3.S3Object
 
 import com.amazonaws.auth._
 import com.amazonaws.services.s3.transfer._
@@ -10,39 +12,38 @@ import better.files._
 
 // TODO: the non-bundle part of the trait could be put in the blast-api lib
 trait AnyBlastReferenceDB extends AnyBundle {
-  val bucket: String
   val name: String
-  val key: String
+
+  val s3Address: S3Object
 
   val destination: File = File(s"${name}.tgz")
   val location: File = File(name)
 
   val dbName: File = File(s"${name}/${name}.fasta")
-}
-
-case object blast16s extends Bundle() with AnyBlastReferenceDB {
-  val bucket = "resources.ohnosequences.com"
-  val name = "era7.16S.reference.sequences.0.1.0"
-  val key = s"16s/${name}.tgz"
-
 
   def instructions: AnyInstructions = {
 
     LazyTry {
-      println(s"""Dowloading
-        |from: s3://${bucket}/${key}
-        |to: ${destination.path}
-        |""".stripMargin)
-
-      // val transferManager = new TransferManager(new ProfileCredentialsProvider("default"))
       val transferManager = new TransferManager(new InstanceProfileCredentialsProvider())
-      val transfer = transferManager.download(bucket, key, destination.toJava)
-      transfer.waitForCompletion
+      transferManager.download(s3Address, destination)
     } -&-
     cmd("tar")("-xvzf", destination.path.toString) -&-
     say(s"Reference database ${name} was dowloaded to ${location.path}")
 
   }
+}
+
+abstract class BlastReferenceDB(
+  val name: String,
+  val s3Address: S3Object
+) extends Bundle() with AnyBlastReferenceDB
+
+
+// Here's the default one:
+case object blast16s extends Bundle() with AnyBlastReferenceDB {
+
+  val name = "era7.16S.reference.sequences.0.1.0"
+  val s3Address = S3Object("resources.ohnosequences.com", s"16s/${name}.tgz")
 }
 
 

--- a/src/main/scala/metagenomica/bundles/blast16s.scala
+++ b/src/main/scala/metagenomica/bundles/blast16s.scala
@@ -8,15 +8,23 @@ import com.amazonaws.services.s3.transfer._
 import better.files._
 
 
-case object blast16s extends Bundle() {
-  // val region = "eu-west-1"
+// TODO: the non-bundle part of the trait could be put in the blast-api lib
+trait AnyBlastReferenceDB extends AnyBundle {
+  val bucket: String
+  val name: String
+  val key: String
+
+  val destination: File = File(s"${name}.tgz")
+  val location: File = File(name)
+
+  val dbName: File = File(s"${name}/${name}.fasta")
+}
+
+case object blast16s extends Bundle() with AnyBlastReferenceDB {
   val bucket = "resources.ohnosequences.com"
   val name = "era7.16S.reference.sequences.0.1.0"
   val key = s"16s/${name}.tgz"
 
-  val destination: File = File(s"${name}.tgz")
-  val location: File = File(name)
-  val dbName: File = File(s"${name}/${name}.fasta")
 
   def instructions: AnyInstructions = {
 

--- a/src/main/scala/metagenomica/loquats/3.blast.scala
+++ b/src/main/scala/metagenomica/loquats/3.blast.scala
@@ -24,7 +24,7 @@ import sys.process._
 case class blastDataProcessing[MD <: AnyMG7Parameters](val md: MD)
 extends DataProcessingBundle(
   bundles.blast,
-  bundles.blast16s
+  md.refDB
 )(
   input = data.blastInput,
   output = data.blastOutput
@@ -60,7 +60,7 @@ extends DataProcessingBundle(
         val expr = blastn(
           outputRecord = md.blastOutRec,
           argumentValues = blastn.arguments(
-            db(bundles.blast16s.dbName) ::
+            db(md.refDB.dbName) ::
             query(readFile) ::
             out(outFile) ::
             *[AnyDenotation]

--- a/src/main/scala/metagenomica/parameters.scala
+++ b/src/main/scala/metagenomica/parameters.scala
@@ -28,6 +28,8 @@ trait AnyMG7Parameters {
   /* This is the number of reads in each chunk after the `split` step */
   // TODO: would be nice to have Nat here
   val chunkSize: Int
+
+  val refDB: bundles.AnyBlastReferenceDB
 }
 
 abstract class MG7Parameters[

--- a/src/main/scala/metagenomica/parameters.scala
+++ b/src/main/scala/metagenomica/parameters.scala
@@ -36,7 +36,8 @@ abstract class MG7Parameters[
   BR <: AnyBlastOutputRecord.For[blastn.type]
 ](val readsLength: illumina.Length,
   val blastOutRec: BR,
-  val chunkSize: Int = 5
+  val chunkSize: Int = 5,
+  val refDB: bundles.AnyBlastReferenceDB
 // )(implicit
   // TODO: add a check for minimal set of properties in the record (like bitscore and sgi)
 ) extends AnyMG7Parameters {

--- a/src/test/scala/metagenomica/pipeline.scala
+++ b/src/test/scala/metagenomica/pipeline.scala
@@ -38,7 +38,8 @@ case object test {
 
   case object testParameters extends MG7Parameters(
     readsLength = bp300,
-    blastOutRec = blastOutRec
+    blastOutRec = blastOutRec,
+    refDB = bundles.blast16s
   )
 
   val defaultAMI = AmazonLinuxAMI(Ireland, HVM, InstanceStore)


### PR DESCRIPTION
The basic idea is that the assignment should be based on

1. the reference sequences have ids as part of their header (the first word after `>`)
2. there's a correspondence ref-id -> ncbi taxonomy