### PR TITLE
Configurable some-id to tax-id mapping

### DIFF
--- a/src/main/scala/metagenomica/bundles/referenceDB.scala
+++ b/src/main/scala/metagenomica/bundles/referenceDB.scala
@@ -33,11 +33,6 @@ trait AnyBlastReferenceDB extends AnyBundle {
   }
 }
 
-abstract class BlastReferenceDB(
-  val name: String,
-  val s3Address: S3Object
-) extends Bundle() with AnyBlastReferenceDB
-
 
 // Here's the default one:
 case object blast16s extends Bundle() with AnyBlastReferenceDB {

--- a/src/main/scala/metagenomica/loquats/3.blast.scala
+++ b/src/main/scala/metagenomica/loquats/3.blast.scala
@@ -24,7 +24,7 @@ import sys.process._
 case class blastDataProcessing[MD <: AnyMG7Parameters](val md: MD)
 extends DataProcessingBundle(
   bundles.blast,
-  md.refDB
+  md.referenceDB
 )(
   input = data.blastInput,
   output = data.blastOutput
@@ -60,7 +60,7 @@ extends DataProcessingBundle(
         val expr = blastn(
           outputRecord = md.blastOutRec,
           argumentValues = blastn.arguments(
-            db(md.refDB.dbName) ::
+            db(md.referenceDB.dbName) ::
             query(readFile) ::
             out(outFile) ::
             *[AnyDenotation]

--- a/src/main/scala/metagenomica/package.scala
+++ b/src/main/scala/metagenomica/package.scala
@@ -3,7 +3,6 @@ package ohnosequences
 package object mg7 {
 
   type ID = String
-  type GI = ID
   type TaxID = ID
   type ReadID = ID
   type NodeID = ID

--- a/src/main/scala/metagenomica/parameters.scala
+++ b/src/main/scala/metagenomica/parameters.scala
@@ -29,7 +29,8 @@ trait AnyMG7Parameters {
   // TODO: would be nice to have Nat here
   val chunkSize: Int
 
-  val refDB: bundles.AnyBlastReferenceDB
+  val referenceDB: bundles.AnyBlastReferenceDB
+  val referenceMap: bundles.AnyReferenceMap
 }
 
 abstract class MG7Parameters[
@@ -37,7 +38,8 @@ abstract class MG7Parameters[
 ](val readsLength: illumina.Length,
   val blastOutRec: BR,
   val chunkSize: Int = 5,
-  val refDB: bundles.AnyBlastReferenceDB
+  val referenceDB: bundles.AnyBlastReferenceDB,
+  val referenceMap: bundles.AnyReferenceMap
 // )(implicit
   // TODO: add a check for minimal set of properties in the record (like bitscore and sgi)
 ) extends AnyMG7Parameters {

--- a/src/test/scala/metagenomica/pipeline.scala
+++ b/src/test/scala/metagenomica/pipeline.scala
@@ -39,7 +39,8 @@ case object test {
   case object testParameters extends MG7Parameters(
     readsLength = bp300,
     blastOutRec = blastOutRec,
-    refDB = bundles.blast16s
+    referenceDB = bundles.blast16s,
+    referenceMap = bundles.filteredGIs
   )
 
   val defaultAMI = AmazonLinuxAMI(Ireland, HVM, InstanceStore)


### PR DESCRIPTION
We use GI to TaxID by default, but for other ref. databases (see #4) another mapping table may be used.