### PR TITLE
Reorganize counts tables

### DIFF
--- a/src/main/scala/metagenomica/data.scala
+++ b/src/main/scala/metagenomica/data.scala
@@ -50,10 +50,18 @@ case object data {
 
 
   // Counting output:
-  case object lcaCountsCSV extends FileData("lca.counts")("csv")
-  case object bbhCountsCSV extends FileData("bbh.counts")("csv")
+  case object lcaDirectCountsCSV extends FileData("lca.direct.counts")("csv")
+  case object bbhDirectCountsCSV extends FileData("bbh.direct.counts")("csv")
+  case object lcaAccumCountsCSV extends FileData("lca.accum.counts")("csv")
+  case object bbhAccumCountsCSV extends FileData("bbh.accum.counts")("csv")
 
   case object countingInput extends DataSet(lcaCSV :×: bbhCSV :×: |[AnyData])
-  case object countingOutput extends DataSet(lcaCountsCSV :×: bbhCountsCSV :×: |[AnyData])
+  case object countingOutput extends DataSet(
+    lcaDirectCountsCSV :×:
+    bbhDirectCountsCSV :×:
+    lcaAccumCountsCSV :×: 
+    bbhAccumCountsCSV :×:
+    |[AnyData]
+  )
 
 }

--- a/src/main/scala/metagenomica/dataflows/standard.scala
+++ b/src/main/scala/metagenomica/dataflows/standard.scala
@@ -123,8 +123,10 @@ case class StandardDataflow[P <: AnyMG7Parameters](val params: P)(
     DataMapping(sampleId, countingDataProcessing)(
       remoteInput = assignmentDM.remoteOutput,
       remoteOutput = Map(
-        data.lcaCountsCSV -> S3Resource(outputS3Folder(sampleId, "counting") / s"${sampleId}.lca.counts.csv"),
-        data.bbhCountsCSV -> S3Resource(outputS3Folder(sampleId, "counting") / s"${sampleId}.bbh.counts.csv")
+        data.lcaDirectCountsCSV -> S3Resource(outputS3Folder(sampleId, "counting") / s"${sampleId}.lca.direct.counts.csv"),
+        data.bbhDirectCountsCSV -> S3Resource(outputS3Folder(sampleId, "counting") / s"${sampleId}.bbh.direct.counts.csv"),
+        data.lcaAccumCountsCSV  -> S3Resource(outputS3Folder(sampleId, "counting") / s"${sampleId}.lca.accum.counts.csv"),
+        data.bbhAccumCountsCSV  -> S3Resource(outputS3Folder(sampleId, "counting") / s"${sampleId}.bbh.accum.counts.csv")
       )
     )
   }


### PR DESCRIPTION
Instead of two tables

- `<SampleN>.bbh.counts.csv`
- `<SampleN>.lca.counts.csv`

we need to have these files

1. `<SampleN>.bbh.direct.absolute.counts.csv`
2. `<SampleN>.bbh.direct.frequency.csv`
3. `<SampleN>.bbh.accumulative.absolute.counts.csv`
4. `<SampleN>.bbh.accumulative.frequency.csv`
5. `<SampleN>.lca.direct.absolute.counts.csv`
6. `<SampleN>.lca.direct.frequency.csv`
7. `<SampleN>.lca.accumulative.absolute.counts.csv`
8. `<SampleN>.lca.accumulative.frequency.csv`

Where

* For each `<SampleN>` we have separate
  - BBH tables
  - LCA tables

* For each algorithm (BBH/LCA):
  + direct counts
    - absolute
    - frequency
  + accumulative counts
    - absolute
    - frequency

Where `frequency = (absolute count) / (number of merged reads in the sample)`

----

P.S. This explanation should go to the docs.

----

In the end we have here (in M2) following files:

1. `<SampleN>.bbh.direct.absolute.counts.csv`
1. `<SampleN>.bbh.accum.absolute.counts.csv`
1. `<SampleN>.lca.direct.absolute.counts.csv`
1. `<SampleN>.lca.accum.absolute.counts.csv`

i.e. without frequency