### PR TITLE
Distinguish FASTA and FASTQ inputs

### DIFF
--- a/src/main/scala/metagenomica/loquats/2.split.scala
+++ b/src/main/scala/metagenomica/loquats/2.split.scala
@@ -32,7 +32,7 @@ case class splitDataProcessing(params: AnyMG7Parameters) extends DataProcessingB
       lazy val chunks: Iterator[(Seq[String], Int)] =
         context.inputFile(data.mergedReads)
           .lines
-          .grouped(4 * params.chunkSize)
+          .grouped(params.blastInputFormat.rows * params.chunkSize)
           .zipWithIndex
 
       chunks foreach { case (chunk, n) =>

--- a/src/main/scala/metagenomica/loquats/3.blast.scala
+++ b/src/main/scala/metagenomica/loquats/3.blast.scala
@@ -40,7 +40,7 @@ extends DataProcessingBundle(
       // NOTE: once we update to better-files 2.15.+, use `file.lineIterator` here (it's autoclosing):
       lazy val source = io.Source.fromFile( context.inputFile(data.readsChunk).toJava )
 
-      source.getLines.grouped(4) foreach { quartet =>
+      source.getLines.grouped(md.blastInputFormat.rows) foreach { quartet =>
         // println(quartet.mkString("\n"))
 
         // we only care about the id and the seq here

--- a/src/main/scala/metagenomica/parameters.scala
+++ b/src/main/scala/metagenomica/parameters.scala
@@ -7,6 +7,9 @@ import ohnosequences.datasets._
 import ohnosequences.flash.api._
 import ohnosequences.blast.api._
 
+sealed trait BlastInputFormat { val rows: Int }
+case object FastaInput extends BlastInputFormat { val rows = 2 }
+case object FastQInput extends BlastInputFormat { val rows = 4 }
 
 trait AnyMG7Parameters {
 
@@ -20,6 +23,8 @@ trait AnyMG7Parameters {
     max_overlap(readsLength.toInt) ::
     *[AnyDenotation]
   )
+
+  val blastInputFormat: BlastInputFormat
 
   type BlastOutRec <: AnyBlastOutputRecord.For[blastn.type]
   val  blastOutRec: BlastOutRec
@@ -38,6 +43,7 @@ abstract class MG7Parameters[
 ](
   val outputS3Folder: (SampleID, StepName) => S3Folder,
   val readsLength: illumina.Length,
+  val blastInputFormat: BlastInputFormat,
   val blastOutRec: BR,
   val blastOptions: blastn.Options := blastn.OptionsVals,
   val chunkSize: Int = 5,

--- a/src/test/scala/lca.scala
+++ b/src/test/scala/lca.scala
@@ -8,11 +8,15 @@ class LCATest extends org.scalatest.FunSuite {
 
     case object root extends AnyTaxonNode {
       val id = "root"
+      val name = "root"
+      val rank = ""
       val parent = None
     }
 
     class node(p: AnyTaxonNode) extends AnyTaxonNode {
       val id = this.toString
+      val name = id
+      val rank = ""
       val parent = Some(p)
     }
 

--- a/src/test/scala/metagenomica/pipeline.scala
+++ b/src/test/scala/metagenomica/pipeline.scala
@@ -38,8 +38,9 @@ case object test {
   case object testParameters extends MG7Parameters(
     outputS3Folder = testOutS3Folder,
     readsLength = bp300,
+    blastInputFormat = FastQInput,
     blastOutRec = defaultBlastOutRec,
-    blastOptions = defaultBlastOptions.value,
+    blastOptions = defaultBlastOptions,
     referenceDB = bundles.rna16s
   )
 


### PR DESCRIPTION
- Flash outputs FASTQ 
- we split it on chunks of 4 rows 
- before passing it to BLAST, we take first 2 rows of those chunks

So this **4** constant should be configurable, to be able to pass FASTA as input to split.