### PR TITLE
Fasta input for pipeline without Flash

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -17,7 +17,7 @@ libraryDependencies ++= Seq(
   // APIs:
   "ohnosequences" %% "flash"      % "0.3.0",
   "ohnosequences" %% "blast-api"  % "0.4.1",
-  "ohnosequences" %% "fastarious" % "0.2.0",
+  "ohnosequences" %% "fastarious" % "0.4.0",
   // generic tools:
   "ohnosequences" %% "cosas"      % "0.8.0",
   "ohnosequences" %% "datasets"   % "0.3.0",

--- a/src/main/scala/metagenomica/data.scala
+++ b/src/main/scala/metagenomica/data.scala
@@ -17,18 +17,18 @@ case object data {
 
 
   // Reads after splitting (multiple files in a virtual S3 folder):
-  case object readsChunks extends Data("reads-chunks")
+  case object fastaChunks extends Data("reads-chunks")
 
   case object splitInput extends DataSet(mergedReads :×: |[AnyData])
-  case object splitOutput extends DataSet(readsChunks :×: |[AnyData])
+  case object splitOutput extends DataSet(fastaChunks :×: |[AnyData])
 
 
   // Blast input:
-  case object readsChunk extends FileData("reads")("fastq")
+  case object fastaChunk extends FileData("reads")("fastq")
   // Blast output for each chunk:
   case object blastChunkOut extends FileData("blast.chunk")("csv")
 
-  case object blastInput extends DataSet(readsChunk :×: |[AnyData])
+  case object blastInput extends DataSet(fastaChunk :×: |[AnyData])
   case object blastOutput extends DataSet(blastChunkOut :×: |[AnyData])
 
 
@@ -59,7 +59,7 @@ case object data {
   case object countingOutput extends DataSet(
     lcaDirectCountsCSV :×:
     bbhDirectCountsCSV :×:
-    lcaAccumCountsCSV :×: 
+    lcaAccumCountsCSV :×:
     bbhAccumCountsCSV :×:
     |[AnyData]
   )

--- a/src/main/scala/metagenomica/dataflows/noFlash.scala
+++ b/src/main/scala/metagenomica/dataflows/noFlash.scala
@@ -37,7 +37,7 @@ trait AnyNoFlashDataflow extends AnyDataflow {
         data.mergedReads -> readsS3Resource
       ),
       remoteOutput = Map(
-        data.readsChunks -> S3Resource(params.outputS3Folder(sampleId, "split"))
+        data.fastaChunks -> S3Resource(params.outputS3Folder(sampleId, "split"))
       )
     )
   }
@@ -52,7 +52,7 @@ trait AnyNoFlashDataflow extends AnyDataflow {
       )
     )
 
-    lazy val chunksS3Folder: AnyS3Address = splitDM.remoteOutput(data.readsChunks).resource
+    lazy val chunksS3Folder: AnyS3Address = splitDM.remoteOutput(data.fastaChunks).resource
 
     lazy val chunks: List[S3Object] = s3.listObjects(chunksS3Folder.bucket, chunksS3Folder.key)
 
@@ -60,7 +60,7 @@ trait AnyNoFlashDataflow extends AnyDataflow {
 
       DataMapping(s"${sampleId}.${n}", blastDataProcessing(params))(
         remoteInput = Map(
-          data.readsChunk -> S3Resource(chunkS3Obj)
+          data.fastaChunk -> S3Resource(chunkS3Obj)
         ),
         remoteOutput = Map(
           data.blastChunkOut -> S3Resource(params.outputS3Folder(sampleId, "blast") / s"blast.${n}.csv")

--- a/src/main/scala/metagenomica/loquats/3.blast.scala
+++ b/src/main/scala/metagenomica/loquats/3.blast.scala
@@ -46,14 +46,14 @@ extends DataProcessingBundle(
         // we only care about the id and the seq here
         val read = FASTA(
             header(FastqId(quartet(0)).toFastaHeader) ::
-            fasta.sequence(FastaLines(quartet(1)))    ::
+            fasta.sequence(FastaSequence(quartet(1)))    ::
             *[AnyDenotation]
           )
 
         val readFile = context / "read.fa"
         readFile
           .createIfNotExists()
-          .appendLines(read.toLines: _*)
+          .appendLine(read.toLines)
 
         val outFile = context / "blastRead.csv"
 

--- a/src/main/scala/metagenomica/loquats/3.blast.scala
+++ b/src/main/scala/metagenomica/loquats/3.blast.scala
@@ -46,7 +46,7 @@ extends DataProcessingBundle(
           *[AnyDenotation]
         )
 
-        val inFile = (context / "read.fa").overwrite(read.toLines)
+        val inFile = (context / "read.fa").overwrite(read.toLines.stripSuffix("\n"))
         val outFile = (context / "blastRead.csv").clear()
 
         val expr = blastn(

--- a/src/main/scala/metagenomica/loquats/3.blast.scala
+++ b/src/main/scala/metagenomica/loquats/3.blast.scala
@@ -40,7 +40,7 @@ extends DataProcessingBundle(
       // NOTE: once we update to better-files 2.15.+, use `file.lineIterator` here (it's autoclosing):
       lazy val source = io.Source.fromFile( context.inputFile(data.readsChunk).toJava )
 
-      source.getLines.grouped(md.blastInputFormat.rows) foreach { quartet =>
+      source.getLines.grouped(md.splitInputFormat.rows) foreach { quartet =>
         // println(quartet.mkString("\n"))
 
         // we only care about the id and the seq here

--- a/src/main/scala/metagenomica/parameters.scala
+++ b/src/main/scala/metagenomica/parameters.scala
@@ -7,14 +7,15 @@ import ohnosequences.datasets._
 import ohnosequences.flash.api._
 import ohnosequences.blast.api._
 
-sealed trait BlastInputFormat { val rows: Int }
-case object FastaInput extends BlastInputFormat { val rows = 2 }
-case object FastQInput extends BlastInputFormat { val rows = 4 }
+sealed trait SplitInputFormat
+case object FastaInput extends SplitInputFormat
+case object FastQInput extends SplitInputFormat
 
 trait AnyMG7Parameters {
 
   val outputS3Folder: (SampleID, StepName) => S3Folder
 
+  /* Flash parameters */
   val readsLength: illumina.Length
 
   // TODO: should it be configurable?
@@ -24,16 +25,18 @@ trait AnyMG7Parameters {
     *[AnyDenotation]
   )
 
-  val blastInputFormat: BlastInputFormat
 
+  /* Split parameters */
+  /* This is the number of reads in each chunk after the `split` step */
+  // TODO: would be nice to have Nat here
+  val splitChunkSize: Int
+  val splitInputFormat: SplitInputFormat
+
+  /* BLAST parameters */
   type BlastOutRec <: AnyBlastOutputRecord.For[blastn.type]
   val  blastOutRec: BlastOutRec
 
   val blastOptions: blastn.Options := blastn.OptionsVals
-
-  /* This is the number of reads in each chunk after the `split` step */
-  // TODO: would be nice to have Nat here
-  val chunkSize: Int
 
   val referenceDB: bundles.AnyReferenceDB
 }
@@ -43,10 +46,10 @@ abstract class MG7Parameters[
 ](
   val outputS3Folder: (SampleID, StepName) => S3Folder,
   val readsLength: illumina.Length,
-  val blastInputFormat: BlastInputFormat,
+  val splitInputFormat: SplitInputFormat = FastQInput,
   val blastOutRec: BR,
   val blastOptions: blastn.Options := blastn.OptionsVals,
-  val chunkSize: Int = 5,
+  val splitChunkSize: Int = 5,
   val referenceDB: bundles.AnyReferenceDB
 // )(implicit
   // TODO: add a check for minimal set of properties in the record (like bitscore and sgi)

--- a/src/test/scala/metagenomica/pipeline.scala
+++ b/src/test/scala/metagenomica/pipeline.scala
@@ -38,7 +38,7 @@ case object test {
   case object testParameters extends MG7Parameters(
     outputS3Folder = testOutS3Folder,
     readsLength = bp300,
-    blastInputFormat = FastQInput,
+    splitInputFormat = FastQInput,
     blastOutRec = defaultBlastOutRec,
     blastOptions = defaultBlastOptions,
     referenceDB = bundles.rna16s


### PR DESCRIPTION
#22 doesn't solve the issue:

We want to pass fasta files as input. If we don't have #21, then the pipeline is as follows:

1. split (which currently splits files on chunks of 2/4 rows, which **doesn't work with Fasta**)
2. blast (which takes each chunk, reads first 2 rows of it and makes out of it a fasta file for Blast)
3. merge
4. assign
5. count

