### PR TITLE
Assignment table's header is treated as a data line

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -16,7 +16,7 @@ resolvers := Seq(
 libraryDependencies ++= Seq(
   // APIs:
   "ohnosequences" %% "flash"      % "0.3.0",
-  "ohnosequences" %% "blast-api"  % "0.4.1",
+  "ohnosequences" %% "blast-api"  % "0.4.2",
   "ohnosequences" %% "fastarious" % "0.4.0",
   // generic tools:
   "ohnosequences" %% "cosas"      % "0.8.0",

--- a/build.sbt
+++ b/build.sbt
@@ -27,8 +27,6 @@ libraryDependencies ++= Seq(
   "ohnosequences-bundles" %% "flash"      % "0.2.0",
   "ohnosequences-bundles" %% "blast"      % "0.3.0",
   "ohnosequences-bundles" %% "bio4j-dist" % "0.1.0",
-  // utils:
-  // "era7"          %% "defaults"  % "0.1.0-SNAPSHOT",
   // testing:
   "org.scalatest" %% "scalatest" % "2.2.6" % Test
 )
@@ -42,27 +40,27 @@ dependencyOverrides ++= Set(
 
 
 
-fatArtifactSettings
-
-// copied from bio4j-titan:
-mergeStrategy in assembly ~= { old => {
-    case "log4j.properties"                       => MergeStrategy.filterDistinctLines
-    case PathList("org", "apache", "commons", _*) => MergeStrategy.first
-    case x                                        => old(x)
-  }
-}
-
-enablePlugins(BuildInfoPlugin)
-buildInfoPackage := "generated.metadata"
-buildInfoObject  := name.value
-buildInfoOptions := Seq(BuildInfoOption.Traits("ohnosequences.statika.AnyArtifactMetadata"))
-buildInfoKeys    := Seq[BuildInfoKey](
-  organization,
-  version,
-  "artifact" -> name.value.toLowerCase,
-  "artifactUrl" -> fatArtifactUrl.value
-)
-
-//// Uncomment for testing: ////
-// For including test code in the fat artifact:
-unmanagedSourceDirectories in Compile += (scalaSource in Test).value / "metagenomica"
+// //// Uncomment for testing: ////
+// fatArtifactSettings
+//
+// // copied from bio4j-titan:
+// mergeStrategy in assembly ~= { old => {
+//     case "log4j.properties"                       => MergeStrategy.filterDistinctLines
+//     case PathList("org", "apache", "commons", _*) => MergeStrategy.first
+//     case x                                        => old(x)
+//   }
+// }
+//
+// enablePlugins(BuildInfoPlugin)
+// buildInfoPackage := "generated.metadata"
+// buildInfoObject  := name.value
+// buildInfoOptions := Seq(BuildInfoOption.Traits("ohnosequences.statika.AnyArtifactMetadata"))
+// buildInfoKeys    := Seq[BuildInfoKey](
+//   organization,
+//   version,
+//   "artifact" -> name.value.toLowerCase,
+//   "artifactUrl" -> fatArtifactUrl.value
+// )
+//
+// // For including test code in the fat artifact:
+// unmanagedSourceDirectories in Compile += (scalaSource in Test).value / "metagenomica"

--- a/build.sbt
+++ b/build.sbt
@@ -16,7 +16,7 @@ resolvers := Seq(
 libraryDependencies ++= Seq(
   // APIs:
   "ohnosequences" %% "flash"      % "0.3.0",
-  "ohnosequences" %% "blast-api"  % "0.4.2",
+  "ohnosequences" %% "blast-api"  % "0.4.3",
   "ohnosequences" %% "fastarious" % "0.4.0",
   // generic tools:
   "ohnosequences" %% "cosas"      % "0.8.0",

--- a/src/main/scala/metagenomica/loquats/5.assignment.scala
+++ b/src/main/scala/metagenomica/loquats/5.assignment.scala
@@ -82,7 +82,13 @@ extends DataProcessingBundle(
     val bbhWriter = CSVWriter.open(bbhFile.toJava, append = true)
 
     // writing headers first:
-    val header = List("Read-ID", "Tax-ID", "Tax-name", "Tax-scientific-name", "Tax-rank")
+    val header = List(
+      columnNames.ReadID,
+      columnNames.TaxID,
+      columnNames.TaxName,
+      columnNames.TaxSciName,
+      columnNames.TaxRank
+    )
     lcaWriter.writeRow(header)
     bbhWriter.writeRow(header)
 

--- a/src/main/scala/metagenomica/package.scala
+++ b/src/main/scala/metagenomica/package.scala
@@ -19,6 +19,15 @@ package object mg7 {
 
   def parseInt(str: String): Option[Int] = util.Try(str.toInt).toOption
 
+  case object columnNames {
+
+    val ReadID = "Read-ID"
+    val TaxID = "Tax-ID"
+    val TaxName = "Tax-name"
+    val TaxSciName = "Tax-scientific-name"
+    val TaxRank = "Tax-rank"
+  }
+
 
   case object defaultBlastOutRec extends BlastOutputRecord(
       outputFields.qseqid   :×:


### PR DESCRIPTION
Counting loquat should ignore the assignment table's header