### PR TITLE
Filter out zero direct counts

### DIFF
--- a/src/main/scala/metagenomica/loquats/6.counting.scala
+++ b/src/main/scala/metagenomica/loquats/6.counting.scala
@@ -84,7 +84,9 @@ case object countingDataProcessing extends DataProcessingBundle(
       csvAccumWriter.writeRow(List(columnNames.TaxID, "Accumulated"))
 
       counts foreach { case (taxId, (dir, acc)) =>
-        csvDirectWriter.writeRow( List(taxId, dir) )
+        // We write only non-zero direct counts
+        if (dir > 0) { csvDirectWriter.writeRow( List(taxId, dir) ) }
+        // Accumulated counts shouldn't be ever a zero
         csvAccumWriter.writeRow( List(taxId, acc) )
       }
 


### PR DESCRIPTION
Requested by @rtobes.
The direct counts table shouldn't contain zeroes.