### PR TITLE
Configurable BLAST command

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -16,7 +16,7 @@ resolvers := Seq(
 libraryDependencies ++= Seq(
   // APIs:
   "ohnosequences" %% "flash"      % "0.3.0",
-  "ohnosequences" %% "blast-api"  % "0.6.0",
+  "ohnosequences" %% "blast-api"  % "0.6.1",
   "ohnosequences" %% "fastarious" % "0.5.1",
   // generic tools:
   "ohnosequences" %% "cosas"      % "0.8.0",
@@ -40,27 +40,27 @@ dependencyOverrides ++= Set(
 
 
 
-//// Uncomment for testing: ////
-fatArtifactSettings
-
-// copied from bio4j-titan:
-mergeStrategy in assembly ~= { old => {
-    case "log4j.properties"                       => MergeStrategy.filterDistinctLines
-    case PathList("org", "apache", "commons", _*) => MergeStrategy.first
-    case x                                        => old(x)
-  }
-}
-
-enablePlugins(BuildInfoPlugin)
-buildInfoPackage := "generated.metadata"
-buildInfoObject  := name.value
-buildInfoOptions := Seq(BuildInfoOption.Traits("ohnosequences.statika.AnyArtifactMetadata"))
-buildInfoKeys    := Seq[BuildInfoKey](
-  organization,
-  version,
-  "artifact" -> name.value.toLowerCase,
-  "artifactUrl" -> fatArtifactUrl.value
-)
+// //// Uncomment for testing: ////
+// fatArtifactSettings
+//
+// // copied from bio4j-titan:
+// mergeStrategy in assembly ~= { old => {
+//     case "log4j.properties"                       => MergeStrategy.filterDistinctLines
+//     case PathList("org", "apache", "commons", _*) => MergeStrategy.first
+//     case x                                        => old(x)
+//   }
+// }
+//
+// enablePlugins(BuildInfoPlugin)
+// buildInfoPackage := "generated.metadata"
+// buildInfoObject  := name.value
+// buildInfoOptions := Seq(BuildInfoOption.Traits("ohnosequences.statika.AnyArtifactMetadata"))
+// buildInfoKeys    := Seq[BuildInfoKey](
+//   organization,
+//   version,
+//   "artifact" -> name.value.toLowerCase,
+//   "artifactUrl" -> fatArtifactUrl.value
+// )
 
 // // For including test code in the fat artifact:
 // unmanagedSourceDirectories in Compile += (scalaSource in Test).value / "metagenomica"

--- a/build.sbt
+++ b/build.sbt
@@ -16,7 +16,7 @@ resolvers := Seq(
 libraryDependencies ++= Seq(
   // APIs:
   "ohnosequences" %% "flash"      % "0.3.0",
-  "ohnosequences" %% "blast-api"  % "0.6.1",
+  "ohnosequences" %% "blast-api"  % "0.6.2",
   "ohnosequences" %% "fastarious" % "0.5.1",
   // generic tools:
   "ohnosequences" %% "cosas"      % "0.8.0",

--- a/build.sbt
+++ b/build.sbt
@@ -16,7 +16,7 @@ resolvers := Seq(
 libraryDependencies ++= Seq(
   // APIs:
   "ohnosequences" %% "flash"      % "0.3.0",
-  "ohnosequences" %% "blast-api"  % "0.5.1",
+  "ohnosequences" %% "blast-api"  % "0.6.0",
   "ohnosequences" %% "fastarious" % "0.5.1",
   // generic tools:
   "ohnosequences" %% "cosas"      % "0.8.0",

--- a/src/main/scala/metagenomica/data.scala
+++ b/src/main/scala/metagenomica/data.scala
@@ -18,7 +18,7 @@ case object data {
   case object flashOutput extends DataSet(
     mergedReads :×:
     pair1NotMerged :×:
-    pair2NotMerged :×: 
+    pair2NotMerged :×:
     flashHistogram :×:
     |[AnyData]
   )
@@ -48,7 +48,7 @@ case object data {
 
   // all output chunks together:
   case object blastChunksFolder extends Data("blast-chunks")
-  case object blastNoHitsFolder extends Data("blast-chunks")
+  case object blastNoHitsFolder extends Data("blast-no-hits")
   // after merging chunks:
   case object blastResult extends FileData("blast")("csv")
   case object blastNoHits extends Data("blast.no-hits")

--- a/src/main/scala/metagenomica/dataflows/noFlash.scala
+++ b/src/main/scala/metagenomica/dataflows/noFlash.scala
@@ -80,7 +80,8 @@ trait AnyNoFlashDataflow extends AnyDataflow {
         data.blastNoHitsFolder -> S3Resource(params.outputS3Folder(sampleId, "blast") / "no-hits" /)
       ),
       remoteOutput = Map(
-        data.blastResult -> S3Resource(params.outputS3Folder(sampleId, "merge") / s"${sampleId}.blast.csv")
+        data.blastResult -> S3Resource(params.outputS3Folder(sampleId, "merge") / s"${sampleId}.blast.csv"),
+        data.blastNoHits -> S3Resource(params.outputS3Folder(sampleId, "merge") / s"${sampleId}.no-hits")
       )
     )
   }

--- a/src/main/scala/metagenomica/loquats/3.blast.scala
+++ b/src/main/scala/metagenomica/loquats/3.blast.scala
@@ -44,15 +44,16 @@ extends DataProcessingBundle(
         val inFile = (context / "read.fa").overwrite(read.asString)
         val outFile = (context / "blastRead.csv").clear()
 
-        val expr = blastn(
+        val expr = BlastExpression(md.blastCommand)(
           outputRecord = md.blastOutRec,
           argumentValues =
-            db(md.referenceDB.dbName) ::
+            db(Set(md.referenceDB.dbName)) ::
             query(inFile) ::
             out(outFile) ::
             *[AnyDenotation],
-          optionValues = md.blastOptions.value
-        )
+          optionValues = md.blastOptions
+        )(md.argValsToSeq, md.optValsToSeq)
+
         println(expr.toSeq.mkString(" "))
 
         // BAM!!

--- a/src/main/scala/metagenomica/loquats/3.blast.scala
+++ b/src/main/scala/metagenomica/loquats/3.blast.scala
@@ -32,8 +32,8 @@ extends DataProcessingBundle(
 
   def process(context: ProcessingContext[Input]): AnyInstructions { type Out <: OutputFiles } = {
 
-    val totalOutput = context / "blastAll.csv"
-    val noHits = context / "no.hits"
+    val totalOutput = (context / "blastAll.csv").createIfNotExists()
+    val noHits = (context / "no.hits").createIfNotExists()
 
     LazyTry {
       // NOTE: once we update to better-files 2.15.+, use `file.lineIterator` here (it's autoclosing):

--- a/src/main/scala/metagenomica/package.scala
+++ b/src/main/scala/metagenomica/package.scala
@@ -2,7 +2,7 @@ package ohnosequences
 
 import ohnosequences.mg7.bio4j.taxonomyTree._
 import ohnosequences.cosas._, types._, klists._
-import ohnosequences.blast.api.{ outputFields => out, _ }
+import ohnosequences.blast.api._
 
 package object mg7 {
 
@@ -29,6 +29,14 @@ package object mg7 {
   }
 
 
+  type BlastArgumentsVals =
+    (db.type    := db.Raw)    ::
+    (query.type := query.Raw) ::
+    (out.type   := out.Raw)   ::
+    *[AnyDenotation]
+
+
+  import ohnosequences.blast.api.{ outputFields => out }
   case object defaultBlastOutRec extends BlastOutputRecord(
     // query
     out.qseqid      :×:

--- a/src/main/scala/metagenomica/package.scala
+++ b/src/main/scala/metagenomica/package.scala
@@ -61,14 +61,14 @@ package object mg7 {
     |[AnyOutputField]
   )
 
-  val defaultBlastOptions: blastn.Options := blastn.OptionsVals =
-    blastn.defaults.update(
-      num_threads(1)                ::
-      word_size(42)                 ::
-      max_target_seqs(10)           ::
-      evalue(BigDecimal(0.001))     ::
-      blastn.task(blastn.megablast) ::
-      *[AnyDenotation]
-    )
+  // val defaultBlastOptions: blastn.Options := blastn.OptionsVals =
+  //   blastn.defaults.update(
+  //     num_threads(1)                ::
+  //     word_size(42)                 ::
+  //     max_target_seqs(10)           ::
+  //     evalue(BigDecimal(0.001))     ::
+  //     blastn.task(blastn.megablast) ::
+  //     *[AnyDenotation]
+  //   )
 
 }

--- a/src/main/scala/metagenomica/parameters.scala
+++ b/src/main/scala/metagenomica/parameters.scala
@@ -56,9 +56,9 @@ class MG7Parameters[
   val readsLength: illumina.Length,
   val splitInputFormat: SplitInputFormat = FastQInput,
   val splitChunkSize: Int = 10,
-  val blastCommand: BC = blastn,
-  val blastOutRec: BR = defaultBlastOutRec,
-  val blastOptions: BC#OptionsVals = defaultBlastOptions.value,
+  val blastCommand: BC, // = blastn,
+  val blastOutRec: BR, // = defaultBlastOutRec,
+  val blastOptions: BC#OptionsVals, // = defaultBlastOptions.value,
   val referenceDB: bundles.AnyReferenceDB = bundles.rnaCentral
 )(implicit
   val optValsToSeq: BlastOptionsToSeq[BC#OptionsVals]

--- a/src/main/scala/metagenomica/parameters.scala
+++ b/src/main/scala/metagenomica/parameters.scala
@@ -33,27 +33,37 @@ trait AnyMG7Parameters {
   val splitInputFormat: SplitInputFormat
 
   /* BLAST parameters */
-  type BlastOutRec <: AnyBlastOutputRecord.For[blastn.type]
+  type BlastCommand <: AnyBlastCommand {
+    type ArgumentsVals = BlastArgumentsVals
+  }
+  val  blastCommand: BlastCommand
+
+  type BlastOutRec <: AnyBlastOutputRecord.For[BlastCommand]
   val  blastOutRec: BlastOutRec
 
-  val blastOptions: blastn.Options := blastn.OptionsVals
+  val blastOptions: BlastCommand#OptionsVals
 
   val referenceDB: bundles.AnyReferenceDB
+
+  val argValsToSeq: BlastOptionsToSeq[BlastArgumentsVals] = implicitly[BlastOptionsToSeq[BlastArgumentsVals]]
+  val optValsToSeq: BlastOptionsToSeq[BlastCommand#OptionsVals] // has to be provided implicitly
 }
 
 abstract class MG7Parameters[
-  BR <: AnyBlastOutputRecord.For[blastn.type]
-](
-  val outputS3Folder: (SampleID, StepName) => S3Folder,
+  BC <: AnyBlastCommand { type ArgumentsVals = BlastArgumentsVals },
+  BR <: AnyBlastOutputRecord.For[BC]
+](val outputS3Folder: (SampleID, StepName) => S3Folder,
   val readsLength: illumina.Length,
   val splitInputFormat: SplitInputFormat = FastQInput,
   val blastOutRec: BR = defaultBlastOutRec,
-  val blastOptions: blastn.Options := blastn.OptionsVals = defaultBlastOptions,
+  val blastOptions: BC#OptionsVals = defaultBlastOptions.value,
   val splitChunkSize: Int = 10,
   val referenceDB: bundles.AnyReferenceDB = bundles.rnaCentral
-// )(implicit
+)(implicit
+  val optValsToSeq: BlastOptionsToSeq[BC#OptionsVals]
   // TODO: add a check for minimal set of properties in the record (like bitscore and sgi)
 ) extends AnyMG7Parameters {
 
+  type BlastCommand = BC
   type BlastOutRec = BR
 }

--- a/src/main/scala/metagenomica/parameters.scala
+++ b/src/main/scala/metagenomica/parameters.scala
@@ -49,15 +49,16 @@ trait AnyMG7Parameters {
   val optValsToSeq: BlastOptionsToSeq[BlastCommand#OptionsVals] // has to be provided implicitly
 }
 
-abstract class MG7Parameters[
+class MG7Parameters[
   BC <: AnyBlastCommand { type ArgumentsVals = BlastArgumentsVals },
   BR <: AnyBlastOutputRecord.For[BC]
 ](val outputS3Folder: (SampleID, StepName) => S3Folder,
   val readsLength: illumina.Length,
   val splitInputFormat: SplitInputFormat = FastQInput,
+  val splitChunkSize: Int = 10,
+  val blastCommand: BC = blastn,
   val blastOutRec: BR = defaultBlastOutRec,
   val blastOptions: BC#OptionsVals = defaultBlastOptions.value,
-  val splitChunkSize: Int = 10,
   val referenceDB: bundles.AnyReferenceDB = bundles.rnaCentral
 )(implicit
   val optValsToSeq: BlastOptionsToSeq[BC#OptionsVals]


### PR DESCRIPTION
We need the type of blast command to be configurable (at the moment `blastn` is hardcoded).