### PR TITLE
Blast no-hits should output reads, not only headers

### DIFF
--- a/src/main/scala/metagenomica/loquats/3.blast.scala
+++ b/src/main/scala/metagenomica/loquats/3.blast.scala
@@ -60,8 +60,8 @@ extends DataProcessingBundle(
         expr.toSeq.!!
 
         val output = outFile.contentAsString
-        // if not BLAST hits, recording read's header
-        if (output.isEmpty) noHits.appendLine(read.getV(header).toString)
+        // if not BLAST hits, recording the read
+        if (output.isEmpty) noHits.appendLine(read.asString)
         // append results for this read to the total output
         else totalOutput.append(output)
       }


### PR DESCRIPTION
An easy change, just accumulate the reads with empty Blast output.