### PR TITLE
Remove not-assigned outs

### DIFF
--- a/src/main/scala/metagenomica/csv.scala
+++ b/src/main/scala/metagenomica/csv.scala
@@ -37,9 +37,7 @@ case object csv {
       "Input-pairs",
       "Merged",
       "Not-merged",
-      "No-Blast-hits",
-      "LCA-not-assigned",
-      "BBH-not-assigned"
+      "No-Blast-hits"
     )
   }
 

--- a/src/main/scala/metagenomica/data.scala
+++ b/src/main/scala/metagenomica/data.scala
@@ -30,7 +30,6 @@ case object data {
 
   // Reads after splitting (multiple files in a virtual S3 folder):
   case object fastaChunks extends Data("reads-chunks")
-  case object mergedReadsNumber extends Data("merged-reads-number")
 
   case object splitInput extends DataSet(mergedReads :×: |[AnyData])
   case object splitOutput extends DataSet(fastaChunks :×: |[AnyData])
@@ -72,15 +71,11 @@ case object data {
   // Assignment output:
   case object lcaCSV extends FileData("lca")("csv")
   case object bbhCSV extends FileData("bbh")("csv")
-  case object lcaNotAssigned extends FileData("lca")("not-assigned")
-  case object bbhNotAssigned extends FileData("bbh")("not-assigned")
 
   case object assignmentInput extends DataSet(blastResult :×: |[AnyData])
   case object assignmentOutput extends DataSet(
     lcaCSV :×:
-    lcaNotAssigned :×:
     bbhCSV :×:
-    bbhNotAssigned :×:
     |[AnyData]
   )
 
@@ -99,7 +94,6 @@ case object data {
   case object countingInput extends DataSet(
     lcaCSV :×:
     bbhCSV :×:
-    mergedReadsNumber :×:
     |[AnyData]
   )
   case object countingOutput extends DataSet(
@@ -124,8 +118,6 @@ case object data {
     mergedReads    :×:
     pair1NotMerged :×:
     blastNoHits    :×:
-    lcaNotAssigned :×:
-    bbhNotAssigned :×:
     |[AnyData]
   )
   case object statsOutput extends DataSet(

--- a/src/main/scala/metagenomica/dataflow.scala
+++ b/src/main/scala/metagenomica/dataflow.scala
@@ -27,9 +27,10 @@ trait AnyDataflow {
       val sampleId = assignmentDM.label
 
       DataMapping(sampleId, countingDataProcessing)(
-        remoteInput =
-          assignmentDM.remoteOutput +
-          (data.mergedReadsNumber -> splitDM.remoteOutput(data.mergedReadsNumber)),
+        remoteInput = Map(
+          data.lcaCSV -> assignmentDM.remoteOutput(data.lcaCSV),
+          data.bbhCSV -> assignmentDM.remoteOutput(data.bbhCSV)
+        ),
         remoteOutput = Map(
           data.lcaDirectCountsCSV -> S3Resource(params.outputS3Folder(sampleId, "counting") / s"${sampleId}.lca.direct.absolute.counts.csv"),
           data.lcaAccumCountsCSV  -> S3Resource(params.outputS3Folder(sampleId, "counting") / s"${sampleId}.lca.accum.absolute.counts.csv"),

--- a/src/main/scala/metagenomica/dataflows/full.scala
+++ b/src/main/scala/metagenomica/dataflows/full.scala
@@ -31,7 +31,7 @@ trait AnyFullDataflow extends AnyNoFlashDataflow {
 
   val flashInputs: Map[SampleID, (S3Resource, S3Resource)]
 
-  lazy val flashDataMappings = flashInputs.toList.map {
+  lazy val flashDataMappings: List[AnyDataMapping] = flashInputs.toList.map {
     case (sampleId, (reads1S3Resource, reads2S3Resource)) =>
 
       DataMapping(sampleId, flashDataProcessing(params))(
@@ -53,7 +53,7 @@ trait AnyFullDataflow extends AnyNoFlashDataflow {
   }.toMap
 
 
-  lazy val statsDataMappings = List[List[AnyDataMapping]](
+  lazy val statsDataMappings: List[AnyDataMapping] = List[List[AnyDataMapping]](
     flashDataMappings,
     mergeDataMappings,
     assignmentDataMappings
@@ -69,18 +69,16 @@ trait AnyFullDataflow extends AnyNoFlashDataflow {
         data.pairedReads1   -> outputs(data.pairedReads1),
         data.mergedReads    -> outputs(data.mergedReads),
         data.pair1NotMerged -> outputs(data.pair1NotMerged),
-        data.blastNoHits    -> outputs(data.blastNoHits),
-        data.lcaNotAssigned -> outputs(data.lcaNotAssigned),
-        data.bbhNotAssigned -> outputs(data.bbhNotAssigned)
+        data.blastNoHits    -> outputs(data.blastNoHits)
       ),
       remoteOutput = Map(
         data.sampleStatsCSV -> S3Resource(params.outputS3Folder("summary", "stats") / s"${sampleId}.stats.csv")
       )
     )
-  }
+  }.toList
 
 
-  lazy val summaryDataMappings = statsDataMappings.map { statsDM =>
+  lazy val summaryDataMappings: List[AnyDataMapping] = statsDataMappings.map { statsDM =>
 
     DataMapping("summmary", summaryDataProcessing)(
       remoteInput = statsDM.remoteOutput,

--- a/src/main/scala/metagenomica/dataflows/full.scala
+++ b/src/main/scala/metagenomica/dataflows/full.scala
@@ -59,20 +59,20 @@ trait AnyFullDataflow extends AnyNoFlashDataflow {
     assignmentDataMappings
   ).flatten
   .groupBy { _.label }
-  .map { case (sampleId: String, dms: List[AnyDataMapping]) =>
+  .map { case (sampleID: String, dms: List[AnyDataMapping]) =>
     val outputs: Map[AnyData, S3Resource] =
       dms.map{ _.remoteOutput }.foldLeft(Map[AnyData, S3Resource]()){ _ ++ _ }
 
-    DataMapping(sampleId, statsDataProcessing)(
-      remoteInput = Map(
-        data.sampleID       -> outputs(data.sampleID),
-        data.pairedReads1   -> outputs(data.pairedReads1),
+    DataMapping(sampleID, statsDataProcessing)(
+      remoteInput = Map[AnyData, AnyRemoteResource](
+        data.sampleID       -> MessageResource(sampleID),
+        data.pairedReads1   -> flashInputs(sampleID)._1,
         data.mergedReads    -> outputs(data.mergedReads),
         data.pair1NotMerged -> outputs(data.pair1NotMerged),
         data.blastNoHits    -> outputs(data.blastNoHits)
       ),
       remoteOutput = Map(
-        data.sampleStatsCSV -> S3Resource(params.outputS3Folder("summary", "stats") / s"${sampleId}.stats.csv")
+        data.sampleStatsCSV -> S3Resource(params.outputS3Folder("summary", "stats") / s"${sampleID}.stats.csv")
       )
     )
   }.toList

--- a/src/main/scala/metagenomica/dataflows/noFlash.scala
+++ b/src/main/scala/metagenomica/dataflows/noFlash.scala
@@ -94,9 +94,7 @@ trait AnyNoFlashDataflow extends AnyDataflow {
       ),
       remoteOutput = Map(
         data.lcaCSV -> S3Resource(params.outputS3Folder(sampleId, "assignment") / s"${sampleId}.lca.csv"),
-        data.bbhCSV -> S3Resource(params.outputS3Folder(sampleId, "assignment") / s"${sampleId}.bbh.csv"),
-        data.lcaNotAssigned -> S3Resource(params.outputS3Folder(sampleId, "assignment") / s"${sampleId}.lca.not-assigned"),
-        data.bbhNotAssigned -> S3Resource(params.outputS3Folder(sampleId, "assignment") / s"${sampleId}.bbh.not-assigned")
+        data.bbhCSV -> S3Resource(params.outputS3Folder(sampleId, "assignment") / s"${sampleId}.bbh.csv")
       )
     )
   }

--- a/src/main/scala/metagenomica/loquats/5.assignment.scala
+++ b/src/main/scala/metagenomica/loquats/5.assignment.scala
@@ -68,11 +68,8 @@ extends DataProcessingBundle(
     blastReader.close
 
     // Now we will write these two types of result to two separate files
-    val lcaFile    = (context / "output" / "lca.csv").createIfNotExists()
-    val bbhFile    = (context / "output" / "bbh.csv").createIfNotExists()
-    val no_lcaFile = (context / "output" / "lca.not-assigned").createIfNotExists()
-    val no_bbhFile = (context / "output" / "bbh.not-assigned").createIfNotExists()
-
+    val lcaFile = (context / "output" / "lca.csv").createIfNotExists()
+    val bbhFile = (context / "output" / "bbh.csv").createIfNotExists()
 
     val lcaWriter = csv.newWriter(lcaFile)
     val bbhWriter = csv.newWriter(bbhFile)
@@ -88,28 +85,16 @@ extends DataProcessingBundle(
     bbhWriter.writeRow(header)
 
     assignments foreach { case (readId, (lca, bbh)) =>
-      lca match {
-        case Some(node) => lcaWriter.writeRow(List(readId, node.id, node.name, node.rank))
-        // TODO: it should also write one of the subject sequences ID
-        case None => no_lcaFile.appendLine(readId)
-      }
-      bbh match {
-        case Some(node) => bbhWriter.writeRow(List(readId, node.id, node.name, node.rank))
-        // TODO: it should also write one of the subject sequences ID
-        case None => no_bbhFile.appendLine(readId)
-      }
+      lca.foreach{ node => lcaWriter.writeRow(List(readId, node.id, node.name, node.rank)) }
+      bbh.foreach{ node => bbhWriter.writeRow(List(readId, node.id, node.name, node.rank)) }
     }
 
     lcaWriter.close
     bbhWriter.close
 
     success(s"Results are ready",
-      // LCA
       data.lcaCSV(lcaFile) ::
-      data.lcaNotAssigned(no_lcaFile) ::
-      // BBH
       data.bbhCSV(bbhFile) ::
-      data.bbhNotAssigned(no_bbhFile) ::
       *[AnyDenotation { type Value <: FileResource }]
     )
   }

--- a/src/main/scala/metagenomica/loquats/7.stats.scala
+++ b/src/main/scala/metagenomica/loquats/7.stats.scala
@@ -46,9 +46,7 @@ case object statsDataProcessing extends DataProcessingBundle()(
         countReads( context.inputFile(data.pairedReads1) ).toString,
         countReads( context.inputFile(data.mergedReads) ).toString,
         countReads( context.inputFile(data.pair1NotMerged) ).toString,
-        countReads( context.inputFile(data.blastNoHits) ).toString,
-        countLines( context.inputFile(data.lcaNotAssigned) ).toString,
-        countLines( context.inputFile(data.bbhNotAssigned) ).toString
+        countReads( context.inputFile(data.blastNoHits) ).toString
       )).toMap
 
       val csvWriter = csv.newWriter(statsCSV)


### PR DESCRIPTION
Due to how we build the reference database, there will be no hits that cannot be mapped to taxa, so these outputs (see #11 and 0529f0b17b5308914a223d3c548442a7cf6a2eab) will be always empty.