### PR TITLE
Debug and fix stats/summary steps

### DIFF
--- a/src/main/scala/metagenomica/dataflows/full.scala
+++ b/src/main/scala/metagenomica/dataflows/full.scala
@@ -81,7 +81,9 @@ trait AnyFullDataflow extends AnyNoFlashDataflow {
   lazy val summaryDataMappings: List[AnyDataMapping] = statsDataMappings.map { statsDM =>
 
     DataMapping("summmary", summaryDataProcessing)(
-      remoteInput = statsDM.remoteOutput,
+      remoteInput = Map(
+        data.sampleStatsFolder -> S3Resource(params.outputS3Folder("summary", "stats"))
+      ),
       remoteOutput = Map(
         data.summaryStatsCSV -> S3Resource(params.outputS3Folder("summary", "stats") / s"summary.csv")
       )

--- a/src/main/scala/metagenomica/dataflows/full.scala
+++ b/src/main/scala/metagenomica/dataflows/full.scala
@@ -72,23 +72,22 @@ trait AnyFullDataflow extends AnyNoFlashDataflow {
         data.blastNoHits    -> outputs(data.blastNoHits)
       ),
       remoteOutput = Map(
-        data.sampleStatsCSV -> S3Resource(params.outputS3Folder("summary", "stats") / s"${sampleID}.stats.csv")
+        data.sampleStatsCSV -> S3Resource(params.outputS3Folder("samples", "stats") / s"${sampleID}.stats.csv")
       )
     )
   }.toList
 
 
-  lazy val summaryDataMappings: List[AnyDataMapping] = statsDataMappings.map { statsDM =>
-
+  lazy val summaryDataMappings: List[AnyDataMapping] = List(
     DataMapping("summmary", summaryDataProcessing)(
       remoteInput = Map(
-        data.sampleStatsFolder -> S3Resource(params.outputS3Folder("summary", "stats"))
+        data.sampleStatsFolder -> S3Resource(params.outputS3Folder("samples", "stats"))
       ),
       remoteOutput = Map(
         data.summaryStatsCSV -> S3Resource(params.outputS3Folder("summary", "stats") / s"summary.csv")
       )
     )
-  }
+  )
 
 }
 

--- a/src/main/scala/metagenomica/loquats/7.stats.scala
+++ b/src/main/scala/metagenomica/loquats/7.stats.scala
@@ -44,21 +44,23 @@ case object statsDataProcessing extends DataProcessingBundle()(
 
     cmd("gunzip")(reads1gz.path.toString) -&-
     LazyTry {
-      // NOTE: careful, the order has to coincide:
-      val stats: Map[String, String] = csv.columnNames.statsHeader.zip(List(
+      val csvWriter = csv.newWriter(statsCSV)
+
+      // header:
+      csvWriter.writeRow(csv.columnNames.statsHeader)
+
+      // values:
+      // NOTE: careful, the order has to coincide with the header
+      // TODO: use csv.Row here
+      val stats: Seq[String] = Seq(
         sampleID,
         countReads( reads1fastq ).toString,
         countReads( context.inputFile(data.mergedReads) ).toString,
         countReads( context.inputFile(data.pair1NotMerged) ).toString,
         countReads( context.inputFile(data.blastNoHits) ).toString
-      )).toMap
+      )
 
-      val csvWriter = csv.newWriter(statsCSV)
-
-      // header:
-      csvWriter.writeRow(stats.keys.toSeq)
-      // values:
-      csvWriter.writeRow(stats.values.toSeq)
+      csvWriter.writeRow(stats)
 
       csvWriter.close()
     } -&-

--- a/src/main/scala/metagenomica/loquats/7.stats.scala
+++ b/src/main/scala/metagenomica/loquats/7.stats.scala
@@ -39,11 +39,15 @@ case object statsDataProcessing extends DataProcessingBundle()(
     val statsCSV: File = context / "output" / "stats.csv"
     val sampleID: String = context.inputFile(data.sampleID).contentAsString
 
+    val reads1gz: File = context.inputFile(data.pairedReads1)
+    val reads1fastq: File = File(reads1gz.path.toString.stripSuffix(".gz"))
+
+    cmd("gunzip")(reads1gz.path.toString) -&-
     LazyTry {
       // NOTE: careful, the order has to coincide:
       val stats: Map[String, String] = csv.columnNames.statsHeader.zip(List(
         sampleID,
-        countReads( context.inputFile(data.pairedReads1) ).toString,
+        countReads( reads1fastq ).toString,
         countReads( context.inputFile(data.mergedReads) ).toString,
         countReads( context.inputFile(data.pair1NotMerged) ).toString,
         countReads( context.inputFile(data.blastNoHits) ).toString

--- a/src/main/scala/metagenomica/loquats/7.stats.scala
+++ b/src/main/scala/metagenomica/loquats/7.stats.scala
@@ -36,7 +36,7 @@ case object statsDataProcessing extends DataProcessingBundle()(
 
   def process(context: ProcessingContext[Input]): AnyInstructions { type Out <: OutputFiles } = {
 
-    val statsCSV: File = context / "output" / "stats.csv"
+    val statsCSV: File = (context / "output" / "stats.csv").createIfNotExists()
     val sampleID: String = context.inputFile(data.sampleID).contentAsString
 
     val reads1gz: File = context.inputFile(data.pairedReads1)

--- a/src/main/scala/metagenomica/loquats/8.summary.scala
+++ b/src/main/scala/metagenomica/loquats/8.summary.scala
@@ -45,12 +45,9 @@ case object summaryDataProcessing extends DataProcessingBundle()(
       // only one level in depth:
       context.inputFile(data.sampleStatsFolder).list foreach { sampleStats =>
 
-        val csvReader = csv.newReader(sampleStats)
-        val rows = csvReader.allWithHeaders().map{ _.values.toSeq }
-
-        csvWriter.writeAll(rows)
-
-        csvReader.close()
+        // an ugly way to drop the header
+        val row = csv.newReader(sampleStats).iterator.drop(1).next()
+        csvWriter.writeRow(row)
       }
 
       csvWriter.close()


### PR DESCRIPTION
I've already fixed some little things in #54. One thing that I noticed during testing:
- [x] counting input reads fails because the input file is an archive. it's easy to fix
- [x] making a map of header-values mixes up the order
- [x] fastq is parsed as fasta