### PR TITLE
Fix reference map accumulation

### DIFF
--- a/src/main/scala/mg7/loquats/4.assign.scala
+++ b/src/main/scala/mg7/loquats/4.assign.scala
@@ -38,7 +38,7 @@ extends DataProcessingBundle()(
     md.referenceDBs.foreach { refDB =>
       val tsvReader = CSVReader.open( refDB.id2taxas.toJava )(csv.UnixTSVFormat)
       tsvReader.iterator.foreach { row =>
-        refMap.updated(
+        refMap.update(
           // first column is the ID
           row(0),
           // second column is a sequence of tax IDs separated with ';'
@@ -52,17 +52,6 @@ extends DataProcessingBundle()(
   }
 
   private def taxIDsFor(id: ID): Seq[TaxID] = referenceMap.get(id).getOrElse(Seq())
-
-  private def maximums[T, X](s: Iterable[T])(f: T => X)
-    (implicit cmp: Ordering[X]): List[T] =
-      s.foldLeft(List[T]()) {
-        case (a :: acc, t) if (    cmp.lt(f(t), f(a)) ) => a :: acc
-        case (a :: acc, t) if ( cmp.equiv(f(t), f(a)) ) => t :: a :: acc
-        // either acc is empty or t is the new maximum
-        case (_, t) => List(t)
-      }
-
-  private def averageOf(vals: Seq[Double]): Double = vals.sum / vals.length
 
 
   def instructions: AnyInstructions = say("Let's see who is who!")

--- a/src/main/scala/mg7/package.scala
+++ b/src/main/scala/mg7/package.scala
@@ -4,7 +4,6 @@ import ohnosequences.mg7.bio4j.taxonomyTree._
 import ohnosequences.cosas._, types._, klists._, typeUnions._
 import ohnosequences.blast.api._
 
-// import com.github.tototoshi.csv._
 import better.files._
 
 package object mg7 {
@@ -25,6 +24,17 @@ package object mg7 {
   def parseDouble(str: String): Option[Double] = util.Try(str.toDouble).toOption
 
   def lookup[A, B](a: A, m: Map[A, B]): (A, B) = a -> m.apply(a)
+
+  def maximums[T, X](s: Iterable[T])(f: T => X)
+    (implicit cmp: Ordering[X]): List[T] =
+      s.foldLeft(List[T]()) {
+        case (a :: acc, t) if (    cmp.lt(f(t), f(a)) ) => a :: acc
+        case (a :: acc, t) if ( cmp.equiv(f(t), f(a)) ) => t :: a :: acc
+        // either acc is empty or t is the new maximum
+        case (_, t) => List(t)
+      }
+
+  def averageOf(vals: Seq[Double]): Double = vals.sum / vals.length
 
 
   type BlastArgumentsVals =


### PR DESCRIPTION
A bug introduced in #66: when [accumulating reference map](https://github.com/ohnosequences/mg7/pull/66/files#diff-4e93c225a0eaadec9445fa00837cab0aR40) should have used mutating `update` instead of `updated`.