### PR TITLE
Improve output formatting

### DIFF
--- a/src/main/scala/mg7/bio4j/taxonomyTree.scala
+++ b/src/main/scala/mg7/bio4j/taxonomyTree.scala
@@ -9,7 +9,7 @@ case object taxonomyTree {
 
     def id: String
     def name: String
-    def rank: String
+    def rankName: String
 
     // root doesn't have parent
     def parent: Option[AnyTaxonNode]
@@ -25,7 +25,7 @@ case object taxonomyTree {
       ancestors_rec(this, Seq())
     }
 
-    def rankNumber: Int = this.rank.trim.toLowerCase match {
+    def rankNumber: Int = this.rankName.trim.toLowerCase match {
       case "superkingdom"     => 1
       case "kingdom"          => 2
       case "superphylum"      => 3
@@ -48,6 +48,8 @@ case object taxonomyTree {
       // "no rank"
       case _ => this.parent.map(_.rankNumber).getOrElse(0) + 1
     }
+
+    def rank: String = s"${this.rankNumber}: ${this.rankName}"
   }
 
   /* Path in the tree stores a sequence of nodes from bottom to top */

--- a/src/main/scala/mg7/bio4j/titanTaxonomyTree.scala
+++ b/src/main/scala/mg7/bio4j/titanTaxonomyTree.scala
@@ -26,7 +26,7 @@ case object titanTaxonomyTree {
     def id: String = titanTaxon.id()
     // These methods may return null
     def name: String = Option( titanTaxon.name() ).getOrElse("")
-    def rank: String = Option( titanTaxon.taxonomicRank() ).getOrElse("")
+    def rankName: String = Option( titanTaxon.taxonomicRank() ).getOrElse("")
 
     def parent: Option[TitanTaxonNode] =
       optional(titanTaxon.ncbiTaxonParent_inV) map TitanTaxonNode

--- a/src/main/scala/mg7/loquats/4.assign.scala
+++ b/src/main/scala/mg7/loquats/4.assign.scala
@@ -122,8 +122,8 @@ extends DataProcessingBundle()(
 
 
         // writing results
-        bbhWriter.writeRow(List(readId, bbhNode.id, bbhNode.name, bbhNode.rank, averageOf(bbhPidents)))
-        lcaWriter.writeRow(List(readId, lcaNode.id, lcaNode.name, lcaNode.rank, averageOf(allPidents)))
+        bbhWriter.writeRow(List(readId, bbhNode.id, bbhNode.name, bbhNode.rank, f"${averageOf(bbhPidents)}%.2f"))
+        lcaWriter.writeRow(List(readId, lcaNode.id, lcaNode.name, lcaNode.rank, f"${averageOf(allPidents)}%.2f"))
       }
 
     blastReader.close

--- a/src/main/scala/mg7/loquats/6.count.scala
+++ b/src/main/scala/mg7/loquats/6.count.scala
@@ -162,7 +162,7 @@ case object countDataProcessing extends DataProcessingBundle(
         )
 
         writerAbs.writeRow(row( absoluteCount.toString ))
-        writerFrq.writeRow(row( f"${frequency(absoluteCount)}%.6f" ))
+        writerFrq.writeRow(row( f"${frequency(absoluteCount) * 100}%.2f" ))
       }
 
       writeCounts(direct,      csvDirectWriter, csvDirectFreqWriter)


### PR DESCRIPTION
As discussed with @rtobes:
- in assignment tables:
 + average `pident`: `%.2f`
- in counts tables:
  + frequency format: `f"${freq * 100}%.2f"`
- add rank-number: `n: rank_name`
