### PR TITLE
Moar significant figures for percentages

### DIFF
--- a/src/main/scala/mg7/loquats/6.count.scala
+++ b/src/main/scala/mg7/loquats/6.count.scala
@@ -162,7 +162,7 @@ case object countDataProcessing extends DataProcessingBundle(
         )
 
         writerAbs.writeRow(row( absoluteCount.toString ))
-        writerFrq.writeRow(row( f"${frequency(absoluteCount) * 100}%.2f" ))
+        writerFrq.writeRow(row( f"${frequency(absoluteCount) * 100}%.4f" ))
       }
 
       writeCounts(direct,      csvDirectWriter, csvDirectFreqWriter)


### PR DESCRIPTION
The taxa frequencies are rounded to zero in more cases than what would be reasonable to expect, leading to values that don't add up to 100% by a significant margin.

A good rule of thumb could be for the frequency percentage be precise enough to detect one read in a sample; we can take `10^6` as an upper bound for the number of reads per sample.

Reported by @rtobes