### PR TITLE
Problem with fully-qualified names

### DIFF
--- a/src/main/scala/mg7/pipeline.scala
+++ b/src/main/scala/mg7/pipeline.scala
@@ -159,11 +159,17 @@ trait AnyMG7Pipeline { pipeline =>
     )
   }
 
-  case object split  extends Loquat(splitConfig,   splitDataProcessing(parameters))(splitDataMappings)
-  case object blast  extends Loquat(blastConfig,   blastDataProcessing(parameters))(blastDataMappings)
-  case object assign extends Loquat(assignConfig, assignDataProcessing(parameters))(assignDataMappings)
-  case object merge  extends Loquat(mergeConfig,   mergeDataProcessing())(mergeDataMappings)
-  case object count  extends Loquat(countConfig,   countDataProcessing())(countDataMappings)
+  lazy val fullName: String = this.getClass.getName.split("\\$").mkString(".")
+  trait FixedName extends AnyLoquat {
+
+    override lazy val fullName: String = s"${pipeline.fullName}.${this.toString}"
+  }
+
+  case object split  extends Loquat(splitConfig,   splitDataProcessing(parameters))(splitDataMappings)  with FixedName
+  case object blast  extends Loquat(blastConfig,   blastDataProcessing(parameters))(blastDataMappings)  with FixedName
+  case object assign extends Loquat(assignConfig, assignDataProcessing(parameters))(assignDataMappings) with FixedName
+  case object merge  extends Loquat(mergeConfig,   mergeDataProcessing())(mergeDataMappings)            with FixedName
+  case object count  extends Loquat(countConfig,   countDataProcessing())(countDataMappings)            with FixedName
 }
 
 
@@ -203,7 +209,7 @@ trait AnyFlashMG7Pipeline extends AnyMG7Pipeline {
     flashDM.label -> flashDM.remoteOutput(data.mergedReads)
   }.toMap
 
-  case object flash extends Loquat(flashConfig, flashDataProcessing(flashParameters))(flashDataMappings)
+  case object flash extends Loquat(flashConfig, flashDataProcessing(flashParameters))(flashDataMappings) with FixedName
 }
 
 /* With the constructor it is just easier to bind the Parameters type member. The rest of the members can be set inside */

--- a/src/main/scala/mg7/pipeline.scala
+++ b/src/main/scala/mg7/pipeline.scala
@@ -175,7 +175,7 @@ trait AnyFlashMG7Pipeline extends AnyMG7Pipeline {
 
   case class FlashConfig(val size: Int) extends AnyFlashConfig  with CommonConfigDefaults
 
-  val flashConfig: AnyFlashConfig = FlashConfig(inputPairedReads.size)
+  val flashConfig: AnyFlashConfig
 
 
   lazy val flashDataMappings: DataMappings[flashDataProcessing] = inputPairedReads.toList.map { case (sampleId, (reads1S3Resource, reads2S3Resource)) =>

--- a/src/test/scala/mg7/fqnames.scala
+++ b/src/test/scala/mg7/fqnames.scala
@@ -8,7 +8,16 @@ class QFNTest extends org.scalatest.FunSuite {
 
   test("Fully-qualified names") {
 
-    info(s"beimock: ${BeiMock.pipeline.toString}")
-    info(s"beimock: ${BeiMock.pipeline.flash.manager.fullName}")
+    info(s"beimock: ${BeiMock.pipeline.fullName}")
+
+    assert {
+       ohnosequences.test.mg7.BeiMock.pipeline.flash.fullName ==
+      "ohnosequences.test.mg7.BeiMock.pipeline.flash"
+    }
+
+    assert {
+       ohnosequences.test.mg7.BeiMock.pipeline.flash.manager.fullName ==
+      "ohnosequences.test.mg7.BeiMock.pipeline.flash.manager"
+    }
   }
 }

--- a/src/test/scala/mg7/fqnames.scala
+++ b/src/test/scala/mg7/fqnames.scala
@@ -1,0 +1,14 @@
+package ohnosequences.test.mg7
+
+import ohnosequences.test.mg7.testDefaults._
+import ohnosequences.mg7._, loquats._
+import ohnosequences.statika._, aws._
+
+class QFNTest extends org.scalatest.FunSuite {
+
+  test("Fully-qualified names") {
+
+    info(s"beimock: ${BeiMock.pipeline.toString}")
+    info(s"beimock: ${BeiMock.pipeline.flash.manager.fullName}")
+  }
+}

--- a/src/test/scala/mg7/illuminaMockCommunitiesRun.scala
+++ b/src/test/scala/mg7/illuminaMockCommunitiesRun.scala
@@ -40,5 +40,7 @@ case object BeiMock {
     val outputS3Folder = testDefaults.outputS3FolderFor("BeiMock")
 
     val flashParameters = FlashParameters(illumina.bp250)
+
+    val flashConfig: AnyFlashConfig = FlashConfig(1)
   }
 }

--- a/src/test/scala/mg7/testDefaults.scala
+++ b/src/test/scala/mg7/testDefaults.scala
@@ -38,11 +38,11 @@ case object testDefaults {
     val iamRoleName = "loquat.testing"
     val logsBucketName = "loquat.testing"
 
-    override val splitConfig  = SplitConfig(1)
-    override val blastConfig  = BlastConfig(100)
-    override val assignConfig = AssignConfig(6)
-    override val mergeConfig  = MergeConfig(1)
-    override val countConfig  = CountConfig(1)
+    val splitConfig  = SplitConfig(1)
+    val blastConfig  = BlastConfig(100)
+    val assignConfig = AssignConfig(6)
+    val mergeConfig  = MergeConfig(1)
+    val countConfig  = CountConfig(1)
   }
 
   lazy val loquatUser = LoquatUser(


### PR DESCRIPTION
Rearrangement of the loquat/statika related things in #112 broke something in the way `manager` compat gets its fully-qualified name. I'm working on a fix.