### PR TITLE
Fix frequency count calculation

### DIFF
--- a/src/main/scala/mg7/loquats/6.count.scala
+++ b/src/main/scala/mg7/loquats/6.count.scala
@@ -140,7 +140,7 @@ case class countDataProcessing() extends DataProcessingBundle(
             columns.AveragePident(averagePidents.get(taxa).getOrElse("-")) ::
             *[AnyDenotation]
           )
-          val percentage: Double = absoluteCount / totalAssignedReads * 100
+          val percentage: Double = (absoluteCount: Double) / totalAssignedReads * 100
 
           absolute.writer.addRow(row( absoluteCount.toString ))
           relative.writer.addRow(row( f"${percentage}%.4f" ))


### PR DESCRIPTION
A stupid bug introduced in the refactoring process:

```
          val percentage: Double = absoluteCount / totalAssignedReads * 100
```

Just need to say explicitly that the numbers divided are `Double`s, not `Int`s.