### PR TITLE
Add pipeline name to the loquats IDs

### DIFF
--- a/src/main/scala/mg7/configs.scala
+++ b/src/main/scala/mg7/configs.scala
@@ -10,6 +10,10 @@ import ohnosequences.blast.api.{ outputFields => out, _ }
 
 trait AnyMG7LoquatConfig extends AnyLoquatConfig {
 
+  val pipelineName: String
+  val stepName: String
+  val loquatName: String = s"${pipelineName}-${stepName}"
+
   lazy val defaultAMI = AmazonLinuxAMI(Ireland, HVM, InstanceStore)
 
   lazy val managerConfig = ManagerConfig(
@@ -32,7 +36,7 @@ trait AnyMG7LoquatConfig extends AnyLoquatConfig {
   )
 }
 
-abstract class MG7LoquatConfig(val loquatName: String) extends AnyMG7LoquatConfig
+abstract class MG7LoquatConfig(val stepName: String) extends AnyMG7LoquatConfig
 
 
 abstract class AnyFlashConfig extends MG7LoquatConfig("flash")

--- a/src/main/scala/mg7/pipeline.scala
+++ b/src/main/scala/mg7/pipeline.scala
@@ -10,19 +10,24 @@ import com.amazonaws.auth._, profile._
 
 trait AnyMG7Pipeline { pipeline =>
 
+
   type Parameters <: AnyMG7Parameters
   val  parameters: Parameters
 
   val inputSamples: Map[SampleID, S3Resource]
   val outputS3Folder: (SampleID, StepName) => S3Folder
 
+  lazy val fullName: String = this.getClass.getName.split("\\$").mkString(".")
+
+  lazy val name: String = fullName
   val metadata: AnyArtifactMetadata
   val iamRoleName: String
   val logsS3Prefix: S3Folder
 
   /* This trait helps to set these common values */
-  trait CommonConfigDefaults {
+  trait CommonConfigDefaults extends AnyMG7LoquatConfig {
 
+    val pipelineName: String          = pipeline.name
     val metadata: AnyArtifactMetadata = pipeline.metadata
     val iamRoleName: String           = pipeline.iamRoleName
     val logsS3Prefix: S3Folder        = pipeline.logsS3Prefix
@@ -155,7 +160,6 @@ trait AnyMG7Pipeline { pipeline =>
     )
   }
 
-  lazy val fullName: String = this.getClass.getName.split("\\$").mkString(".")
   trait FixedName extends AnyLoquat {
 
     override lazy val fullName: String = s"${pipeline.fullName}.${this.toString}"

--- a/src/test/scala/mg7/PRJEB6592/PRJEB6592.scala
+++ b/src/test/scala/mg7/PRJEB6592/PRJEB6592.scala
@@ -29,16 +29,15 @@ case object PRJEB6592 {
   }
 
   case object pipeline extends MG7Pipeline(parameters) with MG7PipelineDefaults {
+    override lazy val name = "PRJEB6592"
 
     val sampleIds: List[ID] = List("ERR567374")
 
-    val commonS3Prefix = S3Folder("resources.ohnosequences.com", "16s/public-datasets/PRJEB6592")
+    val commonS3Prefix = s3"resources.ohnosequences.com/16s/public-datasets/PRJEB6592"/
 
     lazy val inputSamples: Map[SampleID, S3Resource] = sampleIds.map { sampleId =>
       sampleId -> S3Resource(commonS3Prefix / "flash-test" / s"${sampleId}.merged.fastq")
     }.toMap
-
-    lazy val outputS3Folder = testDefaults.outputS3FolderFor("PRJEB6592")
 
     override val splitConfig  = SplitConfig(1)
     override val blastConfig  = BlastConfig(10)

--- a/src/test/scala/mg7/mock/illumina.scala
+++ b/src/test/scala/mg7/mock/illumina.scala
@@ -15,7 +15,7 @@ case object illumina {
 
   case object pipeline extends FlashMG7Pipeline(IlluminaParameters) with MG7PipelineDefaults {
 
-    override val logsS3Prefix = s3"loquat.testing" / "mg7" / "illumina" /
+    override lazy val name = "illumina"
 
     // TODO move all this to the testData object
     /* For now we are only testing one sample */
@@ -34,8 +34,6 @@ case object illumina {
         S3Resource(testData.s3 / "illumina" / s"${id}_2_val_2.fq.gz")
       ))
     }.toMap
-
-    val outputS3Folder = testDefaults.outputS3FolderFor("illumina")
 
     val flashParameters = FlashParameters(bp250)
 

--- a/src/test/scala/mg7/mock/pacbio.scala
+++ b/src/test/scala/mg7/mock/pacbio.scala
@@ -14,7 +14,7 @@ case object pacbio {
 
   case object pipeline extends MG7Pipeline(PacBioParameters) with MG7PipelineDefaults {
 
-    override val logsS3Prefix = s3"loquat.testing" / "mg7" / "pacbio" /
+    override lazy val name = "pacbio"
 
     val sampleIDs: List[ID] = List(
       "stagg",
@@ -26,7 +26,5 @@ case object pacbio {
     val inputSamples: Map[ID, S3Resource] = sampleIDs.map { id =>
       id -> S3Resource(testData.s3 / "pacbio" / s"${id}.subreads_ccs_99.fastq.filter.fastq")
     }.toMap
-
-    val outputS3Folder = testDefaults.outputS3FolderFor("pacbio")
   }
 }

--- a/src/test/scala/mg7/testDefaults.scala
+++ b/src/test/scala/mg7/testDefaults.scala
@@ -30,7 +30,8 @@ case object testDefaults {
 
     val metadata = ohnosequences.generated.metadata.mg7
     val iamRoleName = "loquat.testing"
-    val logsS3Prefix = s3"loquat.testing" /
+    val logsS3Prefix = s3"loquat.testing" / "mg7" / name /
+    val outputS3Folder = testDefaults.outputS3FolderFor(name)
 
     val splitConfig  = SplitConfig(1)
     val blastConfig  = BlastConfig(100)


### PR DESCRIPTION
Currently each loquat ID is based on the loquat name (`split`, `blast`, etc.) and the artifact name/version. So If you have several pipelines defined in the same artifact (like our test pipelines in MG7 itself), you can't run them in parallel, because their loquats' names will coincide. Not a major issue, but should be fixed before the final release.