### PR TITLE
Default parameters presets should be extensible

### DIFF
--- a/src/main/scala/mg7/defaults.scala
+++ b/src/main/scala/mg7/defaults.scala
@@ -65,7 +65,7 @@ case object defaults {
         *[AnyDenotation]
       )
 
-    case class parameters(val refDBs: AnyReferenceDB*) extends MG7Parameters(
+    class Parameters(val refDBs: AnyReferenceDB*) extends MG7Parameters(
       splitInputFormat = FastQInput,
       splitChunkSize   = 1000,
       blastCommand     = blastn,
@@ -73,6 +73,8 @@ case object defaults {
       blastOptions     = blastnOptions.value,
       referenceDBs     = refDBs.toSet
     )
+
+    def apply(refDBs: AnyReferenceDB*): Parameters = new Parameters(refDBs: _*)
   }
 
   case object PacBio {
@@ -87,7 +89,7 @@ case object defaults {
         *[AnyDenotation]
       )
 
-    case class parameters(val refDBs: AnyReferenceDB*) extends MG7Parameters(
+    class Parameters(val refDBs: AnyReferenceDB*) extends MG7Parameters(
       splitInputFormat = FastQInput,
       splitChunkSize   = 100,
       blastCommand     = blastn,
@@ -95,6 +97,8 @@ case object defaults {
       blastOutRec      = defaults.blastnOutputRecord,
       referenceDBs     = refDBs.toSet
     )
+
+    def apply(refDBs: AnyReferenceDB*): Parameters = new Parameters(refDBs: _*)
   }
 
 }

--- a/src/test/scala/mg7/mock/illumina.scala
+++ b/src/test/scala/mg7/mock/illumina.scala
@@ -13,7 +13,7 @@ import com.amazonaws.auth._, profile._
 
 case object illumina {
 
-  case object pipeline extends FlashMG7Pipeline(IlluminaParameters) with MG7PipelineDefaults {
+  case object pipeline extends FlashMG7Pipeline(defaults.Illumina(rna16sRefDB)) with MG7PipelineDefaults {
 
     override lazy val name = "illumina"
 

--- a/src/test/scala/mg7/mock/pacbio.scala
+++ b/src/test/scala/mg7/mock/pacbio.scala
@@ -12,7 +12,7 @@ import com.amazonaws.auth._, profile._
 
 case object pacbio {
 
-  case object pipeline extends MG7Pipeline(PacBioParameters) with MG7PipelineDefaults {
+  case object pipeline extends MG7Pipeline(defaults.PacBio(rna16sRefDB)) with MG7PipelineDefaults {
 
     override lazy val name = "pacbio"
 

--- a/src/test/scala/mg7/testDefaults.scala
+++ b/src/test/scala/mg7/testDefaults.scala
@@ -45,7 +45,4 @@ case object testDefaults {
     localCredentials = new ProfileCredentialsProvider("default"),
     keypairName = "aalekhin"
   )
-
-  val IlluminaParameters = defaults.Illumina.parameters(rna16sRefDB)
-  val PacBioParameters = defaults.PacBio.parameters(rna16sRefDB)
 }


### PR DESCRIPTION
Currently one cannot take `defaults.PacBio.parameters` and override just one parameter. Making it a `class` would be enough.