### PR TITLE
Stabilize dependencies

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -22,6 +22,7 @@ libraryDependencies ++= Seq(
   "ohnosequences" %% "statika"      % "2.0.0",
   "ohnosequences" %% "datasets"          % "0.4.1",
   "ohnosequences" %% "datasets-illumina" % "0.1.0",
+  "com.github.tototoshi" %% "scala-csv" % "1.3.4",
   // bundles:
   "ohnosequences-bundles" %% "flash" % "0.3.0",
   "ohnosequences-bundles" %% "blast" % "0.4.0"

--- a/build.sbt
+++ b/build.sbt
@@ -25,9 +25,9 @@ libraryDependencies ++= Seq(
   "com.github.tototoshi" %% "scala-csv" % "1.3.4",
   // bundles:
   "ohnosequences-bundles" %% "flash" % "0.3.0",
-  "ohnosequences-bundles" %% "blast" % "0.4.0"
+  "ohnosequences-bundles" %% "blast" % "0.4.0",
   // testing:
-  // "ohnosequences" %% "db-rna16s" % "0.12.0" % Test
+  "ohnosequences" %% "db-rna16s" % "1.0.0-RC1" % Test
 )
 
 dependencyOverrides ++= Set(

--- a/build.sbt
+++ b/build.sbt
@@ -24,9 +24,9 @@ libraryDependencies ++= Seq(
   "ohnosequences" %% "datasets-illumina" % "0.1.0",
   // bundles:
   "ohnosequences-bundles" %% "flash" % "0.3.0",
-  "ohnosequences-bundles" %% "blast" % "0.4.0",
+  "ohnosequences-bundles" %% "blast" % "0.4.0"
   // testing:
-  "ohnosequences" %% "db-rna16s" % "0.12.0" % Test
+  // "ohnosequences" %% "db-rna16s" % "0.12.0" % Test
 )
 
 dependencyOverrides ++= Set(

--- a/build.sbt
+++ b/build.sbt
@@ -12,29 +12,24 @@ resolvers := Seq(
 
 libraryDependencies ++= Seq(
   // APIs:
-  "ohnosequences" %% "flash"        % "0.3.0",
-  "ohnosequences" %% "fastarious"   % "0.6.0",
-  "ohnosequences" %% "blast-api"    % "0.7.0",
-  "ohnosequences" %% "ncbitaxonomy" % "0.1.0",
+  "ohnosequences" %% "ncbitaxonomy" % "0.2.0",
+  "ohnosequences" %% "fastarious"   % "0.8.0",
+  "ohnosequences" %% "blast-api"    % "0.8.0",
+  "ohnosequences" %% "flash-api"    % "0.4.0",
   // generic tools:
   "ohnosequences" %% "cosas"        % "0.8.0",
-  "ohnosequences" %% "loquat"       % "2.0.0-M9",
-  "ohnosequences" %% "statika"      % "2.0.0-RC2",
+  "ohnosequences" %% "loquat"       % "2.0.0-RC1",
+  "ohnosequences" %% "statika"      % "2.0.0",
   "ohnosequences" %% "datasets"          % "0.4.1",
   "ohnosequences" %% "datasets-illumina" % "0.1.0",
   // bundles:
-  "ohnosequences-bundles" %% "flash" % "0.2.0",
-  "ohnosequences-bundles" %% "blast" % "0.3.0",
+  "ohnosequences-bundles" %% "flash" % "0.3.0",
+  "ohnosequences-bundles" %% "blast" % "0.4.0",
   // testing:
   "ohnosequences" %% "db-rna16s" % "0.12.0" % Test
 )
 
 dependencyOverrides ++= Set(
-  // FIXME: this has to be updated in the other dependencies
-  "ohnosequences" %% "statika" % "2.0.0-RC2",
-  "ohnosequences" %% "aws-scala-tools" % "0.18.1",
-  "com.github.pathikrit" %% "better-files" % "2.16.0",
-  /////
   "org.apache.httpcomponents" % "httpclient" % "4.5.1",
   "org.slf4j"                 % "slf4j-api"  % "1.7.7"
 )

--- a/src/main/scala/mg7/defaults.scala
+++ b/src/main/scala/mg7/defaults.scala
@@ -13,7 +13,6 @@ case object defaults {
     blastn.options(
       /* This actually depends on the workers instance type */
       num_threads(4)              ::
-      blastn.task(blastn.blastn)  ::
       evalue(BigDecimal(1E-100))  ::
       max_target_seqs(10000)      ::
       strand(Strands.both)        ::

--- a/src/main/scala/mg7/loquats/1.flash.scala
+++ b/src/main/scala/mg7/loquats/1.flash.scala
@@ -28,12 +28,12 @@ extends DataProcessingBundle(
 
     // define input
     lazy val flashInput = FlashInputAt(
-      reads1fastq,
-      reads2fastq
+      reads1fastq.toJava,
+      reads2fastq.toJava
     )
 
     // define output
-    lazy val flashOutput = FlashOutputAt((context / "output"), prefix = "")
+    lazy val flashOutput = FlashOutputAt((context / "output").toJava, prefix = "")
 
     // the FLASh cmd we are going to run
     lazy val flashExpr = FlashExpression(
@@ -50,10 +50,10 @@ extends DataProcessingBundle(
     seqToInstructions(flashExpr.cmd)      -&-
     success(
       "FLASh merged reads, much success so fast",
-      data.mergedReads(flashOutput.mergedReads.toJava) ::
-      data.pair1NotMerged(flashOutput.pair1NotMerged.toJava) ::
-      data.pair2NotMerged(flashOutput.pair2NotMerged.toJava) ::
-      data.flashHistogram(flashOutput.lengthNumericHistogram.toJava) ::
+      data.mergedReads(flashOutput.mergedReads) ::
+      data.pair1NotMerged(flashOutput.pair1NotMerged) ::
+      data.pair2NotMerged(flashOutput.pair2NotMerged) ::
+      data.flashHistogram(flashOutput.lengthNumericHistogram) ::
       *[AnyDenotation { type Value <: FileResource }]
     )
   }

--- a/src/main/scala/mg7/loquats/2.split.scala
+++ b/src/main/scala/mg7/loquats/2.split.scala
@@ -29,7 +29,7 @@ case class splitDataProcessing(parameters: AnyMG7Parameters) extends DataProcess
         // if input is FastQ, we parse it, convert it to FASTA and get String version
         case FastQInput => fastq.parseFastqDropErrors(lines).map(_.toFASTA.asString)
         // if it's Fasta, we parse it and get String version
-        case FastaInput => fasta.parseFastaDropErrors(lines).map(_.asString)
+        case FastaInput => lines.buffered.parseFastaDropErrors().map(_.asString)
       }
 
       // group it

--- a/src/main/scala/mg7/loquats/3.blast.scala
+++ b/src/main/scala/mg7/loquats/3.blast.scala
@@ -33,7 +33,7 @@ extends DataProcessingBundle(
       val source = io.Source.fromFile( context.inputFile(data.fastaChunk).toJava )
       val totalOutputWriter = csv.Writer(parameters.blastOutRec.keys)(totalOutput)
 
-      fasta.parseFastaDropErrors(source.getLines) foreach { read =>
+      source.getLines.buffered.parseFastaDropErrors() foreach { read =>
         println(s"\nRunning BLAST for the read ${read.getV(header).id}")
 
         val inFile = (context / "read.fa").overwrite(read.asString)

--- a/src/main/scala/mg7/parameters.scala
+++ b/src/main/scala/mg7/parameters.scala
@@ -46,9 +46,9 @@ trait AnyMG7Parameters {
     BlastExpression(blastCommand)(
       outputRecord = blastOutRec,
       argumentValues =
-        db(referenceDBs.map(_.blastDBName)) ::
-        query(inFile) ::
-        ohnosequences.blast.api.out(outFile) ::
+        db(referenceDBs.map(_.blastDBName.toJava)) ::
+        query(inFile.toJava) ::
+        ohnosequences.blast.api.out(outFile.toJava) ::
         *[AnyDenotation],
       optionValues = blastOptions
     )(argValsToSeq, optValsToSeq)

--- a/src/main/scala/mg7/pipeline.scala
+++ b/src/main/scala/mg7/pipeline.scala
@@ -18,7 +18,7 @@ trait AnyMG7Pipeline { pipeline =>
   val outputS3Folder: (SampleID, StepName) => S3Folder
 
   lazy val fullName: String = this.getClass.getName.split("\\$").mkString(".")
-  lazy val name: String = fullName.replace(".", "-").toLowerCase
+  lazy val name: String = fullName.split('.').last.toLowerCase
 
   val metadata: AnyArtifactMetadata
   val iamRoleName: String


### PR DESCRIPTION
There are several dependency overrides in M5 which should be fixed in RC1.

APIs:
- [x] https://github.com/ohnosequences/fastarious/issues/19: v0.8.0
- [x] https://github.com/ohnosequences/blast-api/issues/47: v0.8.0
- [x] https://github.com/ohnosequences/flash/issues/17: v0.4.0

Bundles:
- [x] https://github.com/ohnosequences/ncbitaxonomy/issues/2
  + [x] https://github.com/ohnosequences-bundles/bio4j-dist/issues/3
- [x] https://github.com/ohnosequences-bundles/blast/issues/15
- [x] https://github.com/ohnosequences-bundles/flash/issues/6
  + [x] https://github.com/ohnosequences-bundles/cdevel/issues/2
  + [x] https://github.com/ohnosequences-bundles/compressinglibs/issues/3
